### PR TITLE
feat: allow hotfix merges to master

### DIFF
--- a/.github/workflows/get-pr.yml
+++ b/.github/workflows/get-pr.yml
@@ -27,9 +27,11 @@ jobs:
 
             const pr = prResponse[0];
             if (!pr) throw new Error('Could not find PR.');
-            
+
             let type = '';
-            if (pr.base.ref === 'master' && pr.head.ref === 'dev') {
+
+            // pr to master is a release, to dev is a feature
+            if (pr.base.ref === 'master') {
               type = 'release';
             } else if (pr.base.ref === 'dev') {
               type = 'feature';


### PR DESCRIPTION
This allows arbitrary merges to master in order to allow hotfixes to bypass the dev branch.