### PR TITLE
feat: docker multi arch images

### DIFF
--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -22,11 +22,12 @@ jobs:
           IMAGE_ID=ghcr.io/${{ github.repository }}
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 
-          # build docker image
-          docker build . --file Dockerfile --tag $IMAGE_ID:next
-
           # log into docker registry
           echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-          # push images
-          docker push $IMAGE_ID:next
+          # build docker images and push to registry
+          docker buildx build . \
+            --file Dockerfile \
+            --tag $IMAGE_ID:next \
+            --platform linux/amd64,linux/arm64 \
+            --push

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           ref: "dev"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build and Publish Docker Image @:next
         run: |
           # copose image ID and change all uppercase to lowercase

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -100,12 +100,13 @@ jobs:
           VERSION=${{ steps.changelog.outputs.tag }}
           VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # build docker image
-          docker build . --file Dockerfile --tag $IMAGE_ID:latest --tag $IMAGE_ID:$VERSION
-
           # log into docker registry
           echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-          # push images
-          docker push $IMAGE_ID:latest
-          docker push $IMAGE_ID:$VERSION
+          
+          # build docker image and push to registry
+          docker buildx build . \
+            --file Dockerfile \
+            --tag $IMAGE_ID:latest \
+            --tag $IMAGE_ID:$VERSION \
+            --platform linux/amd64,linux/arm64 \
+            --push

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -89,6 +89,12 @@ jobs:
               repo: context.repo.repo,
               title: 'next'
             });
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Build and Publish Docker Image @:latest and @:v_._._
         run: |


### PR DESCRIPTION
This closes https://github.com/dot-base/.github/issues/12.

We need to build our docker images for multiple architectures (`amd64` and `arm64`) since we need to be able to develop on MacBooks based on Apple silicon (M1 etc.).

This PR uses `docker buildx` to simply build multi arch images. The `docker buildx build` also includes pushing the images to the registry (with `--push`), so we can get rid of the separate `docker push` commands.
In order to use `docker buildx` we need to setup it using the [`setup-buildx-action`](https://github.com/docker/setup-buildx-action#usage) action.

The [github action mentioned](https://github.com/crazy-max/ghaction-docker-buildx) in the docker guide is deprecated. However it mentions the correct docker gh actions that we can use:
```
      # https://github.com/docker/setup-qemu-action
      - name: Set up QEMU
        uses: docker/setup-qemu-action@v1
      # https://github.com/docker/setup-buildx-action
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v1
```

**Reference**
* [Docker guide on building multi arch images](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/#:~:text=Let%E2%80%99s%20go%20to%20production)
* [GH action to setup buildx mentioned in the docker guide](https://github.com/crazy-max/ghaction-docker-buildx)
* [Docker Setup Qemu GH action](https://github.com/docker/setup-qemu-action)
* [Docker Buildx GH action](https://github.com/docker/setup-buildx-action)
