### PR TITLE
chore: update github action versions

### DIFF
--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: "dev"
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: "dev"
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,8 +3,10 @@ name: Create Release
 on:
   workflow_call:
     secrets:
-      GH_BOT_PAT:
+      GH_BOT_USER:
         required: true
+      GH_BOT_PAT:
+        required: true        
       CR_PAT:
         required: true
     outputs:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,7 +22,7 @@ jobs:
       tag: ${{ steps.changelog.outputs.tag }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_BOT_PAT }}
           ref: "master"
@@ -62,7 +62,7 @@ jobs:
           git push
 
       - name: Manage Milestones
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_PAT }}
           script: |

--- a/.github/workflows/get-pr.yml
+++ b/.github/workflows/get-pr.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get PR
         id: get_pr
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_PAT }}
           script: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Check Out Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set Up Node.js v16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint PR Title
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_PAT }}
           script: |

--- a/.github/workflows/merge-feature-pr.yml
+++ b/.github/workflows/merge-feature-pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge Feature PR
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_PAT }}
           script: |

--- a/.github/workflows/merge-release-pr.yml
+++ b/.github/workflows/merge-release-pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge Release PR
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_PAT }}
           script: |


### PR DESCRIPTION
Updating the used github action versions since they are throwing deprecation warnings:
```
Get PR / Get PR
The following actions uses node12 which is deprecated and will be forced to run on node16:
actions/github-script@v5. For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```
https://github.com/dot-base/medical-dashboard/actions/runs/5680732956