### PR TITLE
Update GH PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 This closes https://github.com/dot-base/medical-dashboard/issues/XXXX
 
+BREAKING CHANGE: some breaking change description or DELETE this line. 🚨
+
 # Description 📖
 Provide a description of the changes. Also include motivation and context of the changes.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,26 @@
-This introduces/fixes/improves feature/bug/enhancement description. This closes #1337.
+# Ticket 🎫
 
-BREAKING CHANGE: some breaking change description or DELETE this line.
+This closes https://github.com/dot-base/medical-dashboard/issues/XXXX
+
+# Description 📖
+Provide a description of the changes. Also include motivation and context of the changes.
+
+# How to Test? 🧪
+
+Provide a list of instructions how to test the changes of this PR.
+
+# Is there something controversial ? 🚨
+
+Take sometime time to explain your choices.
+This can also include further thoughts, ideas and improvements.
+
+# References (optional) 🔗
+
+Add any references to other issues, PRs or external links if applicable.
+
+# Checklist ✅
+- [ ] My changes generate no new warnings
+- [ ] Made corresponding changes to the documentation if applicable
+- [ ] Commented my code, particularly in hard-to-understand areas if applicable
+- [ ] Performed a self-review of my own changes
+- [ ] Added relevant unit tests


### PR DESCRIPTION
# Ticket 🎫

This closes https://github.com/dot-base/medical-dashboard/issues/1246

# Description 📖

Added GitHub PR template: Whenever you open a PR, this template will be prefilled.
Just add your information and remove sections that are not needed.

# How to Test? 🧪
(Right now, this would not work, as these changes need to be on `master` branch first)
1. Create a new PR
2. Acknowledge that PR description text area is prefilled using this template


# Is there something controversial ? 🚨

Changing the template here will change it for all repositories, as the `.github` repo is a template reporitory.

# References (optional) 🔗

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- https://www.awesomecodereviews.com/pull-request-template/
- https://levelup.gitconnected.com/how-pull-request-templates-can-improve-your-github-workflow-9114a17cb360

# Checklist ✅
- [x] My changes generate no new warnings
- [x] Made corresponding changes to the documentation if applicable
- [x] Commented my code, particularly in hard-to-understand areas if applicable
- [x] Performed a self-review of my own changes
- [x] Added relevant unit tests