### PR TITLE
feat: create service releases as prerelease

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -78,6 +78,7 @@ jobs:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
+          prerelease: true
 
       - name: Manage Milestones
         uses: actions/github-script@v6


### PR DESCRIPTION
# Ticket 🎫

This is part of #33.

# Description 📖
This creates service releases initially as prerelease. They are turned into full releases after a full dotbase release.
