### PR TITLE
fix: pin old conventional changelog version before esm

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -37,11 +37,11 @@ jobs:
         env:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
         run: |
-          npm i conventional-changelog-conventionalcommits
+          npm i conventional-changelog-conventionalcommits@v7.0.2
 
       - name: Generate Changelog
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v3
+        uses: TriPSs/conventional-changelog-action@v5.3.0
         with:
           github-token: ${{ secrets.github_token }}
           release-count: 0                                  # keep all changes in changelog

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,11 +45,11 @@ jobs:
         env:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
         run: |
-          npm i conventional-changelog-conventionalcommits
+          npm i conventional-changelog-conventionalcommits@v7.0.2
 
       - name: Generate Changelog
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v3
+        uses: TriPSs/conventional-changelog-action@v5.3.0
         with:
           github-token: ${{ secrets.github_token }}
           release-count: 0 # keep all changes in changelog


### PR DESCRIPTION
# Ticket 🎫

This closes #58.

# Description 📖
Pin old conventional changelog version before esm to avoid error because of `require` in changelog config.

