### PR TITLE
fix: add missing mandatory workflow secret

### DIFF
--- a/.github/workflows/merge-release-pr.yml
+++ b/.github/workflows/merge-release-pr.yml
@@ -122,3 +122,4 @@ jobs:
       tag: ${{ needs.create-release.outputs.tag }}
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_BOT_PAT: ${{ secrets.GH_BOT_PAT }}


### PR DESCRIPTION
# Description 📖
[This commit](https://github.com/dot-base/.github/commit/d0a30f9644126a8f518247b79a553841ccb5ae92) made the `GH_BOT_PAT` secret mandatory for the `fhir-resource-npm-publish` workflow. This PR adds the missing token.
This error breaks all pipelines of all repos: https://github.com/dot-base/dotstudio/actions/runs/9190712198

