### PR TITLE
chore: pass FONTAWESOME_NPM_AUTH_TOKEN as secret instead of build-arg

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -79,7 +79,7 @@ jobs:
                   --file Dockerfile \
                   --tag $IMAGE_ID:latest \
                   --tag $IMAGE_ID:$VERSION \
-                  --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }} \
+                  --secret id=fontawesome_token,env=FONTAWESOME_NPM_AUTH_TOKEN \
                   --platform $PLATFORM \
                   --push ; \
           fi

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -45,7 +45,7 @@ jobs:
             else docker buildx build . \
                   --file Dockerfile \
                   --tag $IMAGE_ID:next \
-                  --build-arg FONTAWESOME_NPM_AUTH_TOKEN=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }} \
+                  --secret id=fontawesome_token,env=FONTAWESOME_NPM_AUTH_TOKEN \
                   --platform linux/amd64 \
                   --push ; \
           fi


### PR DESCRIPTION
# Ticket 🎫

This closes https://github.com/dot-base/.github/issues/66.
BREAKING CHANGE: This removes passing the fontawesome as a build arg and requires changes in the Dockerfiles for dotclinic and dotstudio 🚨

:exclamation:  **Once this is merged the following PRs need to be merged too:** :exclamation:
- https://github.com/dot-base/dotclinic/pull/1995

