### PR TITLE
chore: add checklist for breaking changes to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,19 @@
 # Ticket 🎫
 
-This closes https://github.com/dot-base/medical-dashboard/issues/XXXX
-
-BREAKING CHANGE: some breaking change description or DELETE this line. 🚨
+This closes https://github.com/dot-base/dotclinic/issues/XXXX
 
 # Description 📖
 Provide a description of the changes. Also include motivation and context of the changes.
+
+# Breaking Changes ⚡️
+
+This PR has
+- [ ] no migrations
+- [ ] no API changes
+- [ ] no config changes
+- [ ] no changes that require a change in other repos
+
+Is there a breaking change? If you cannot tick all boxes, please provide a description of the breaking changes.
 
 ## Is there something controversial ? 🚨
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,21 @@
 # Ticket 🎫
-
 This closes https://github.com/dot-base/dotclinic/issues/XXXX
 
 # Description 📖
 Provide a description of the changes. Also include motivation and context of the changes.
 
-# Breaking Changes ⚡️
+## Is there something controversial ? 🚨
+Take sometime time to explain your choices.
+This can also include further thoughts, ideas and improvements.
 
+# How to Test? 🧪
+Provide a list of instructions how to test the changes of this PR.
+
+# Breaking Changes ⚡️
 This PR has
 - [ ] no migrations
 - [ ] no API changes
 - [ ] no config changes
 - [ ] no changes that require a change in other repos
 
-Is there a breaking change? If you cannot tick all boxes, please provide a description of the breaking changes.
-
-## Is there something controversial ? 🚨
-
-Take sometime time to explain your choices.
-This can also include further thoughts, ideas and improvements.
-
-# How to Test? 🧪
-
-Provide a list of instructions how to test the changes of this PR.
+BREAKING CHANGE: If you cannot tick all boxes, there is a breaking change. In this case, add a description here after the keyword. Otherwise delete this line.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,4 @@ This PR has
 - [ ] no config changes
 - [ ] no changes that require a change in other repos
 
-BREAKING CHANGE: If you cannot tick all boxes, there is a breaking change. In this case, add a description here after the keyword. Otherwise delete this line.
+BREAKING CHANGE: If you cannot tick all boxes, there is a breaking change. In this case, add a description here after the keyword. Otherwise DELETE this line.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,4 @@ This PR has
 - [ ] no config changes
 - [ ] no changes that require a change in other repos
 
-BREAKING CHANGE: If you cannot tick all boxes, there is a breaking change. In this case, add a description here after the keyword. Otherwise DELETE this line.
+BREAKING CHANGE: If you cannot tick all boxes, there is a breaking change. In this case, add a description here after the keyword. Otherwise DELETE this line or it will falsely trigger a major version change.


### PR DESCRIPTION
Adds a checklist for breaking changes to our PR template.

I used this opportunity to change the issue url from referencing `medical-dashboard` to `dotclinic`.