### PR TITLE
feat: Add coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
         run: npm install
       - name: "Test"
-        run: npx vitest --coverage.enabled true --coverage.reporter=json-summary || true
+        run: npx vitest --coverage.enabled true --coverage.reporter=json-summary --coverage.reporter=json || true
       - name: "Upload Coverage"
         uses: actions/upload-artifact@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
         run: npm install
       - name: "Test"
-        run: npx vitest --coverage.enabled true --coverage.reporter=json-summary || true
+        run: npx vitest --coverage.enabled true --coverage.reporter=json-summary --coverage.reporter=json || true
       - name: "Upload Coverage"
         uses: actions/upload-artifact@v4
         with:
@@ -98,6 +98,8 @@ jobs:
     permissions:
       # Required to checkout the code
       contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-pr
-          path: coverage
+          path: coverage-pr
         env:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
@@ -87,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-main
-          path: coverage
+          path: coverage-main
         env:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
@@ -109,11 +109,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-pr
-          path: coverage
+          path: coverage-pr
       - uses: actions/download-artifact@v4
         with:
           name: coverage-main
-          path: coverage
+          path: coverage-main
       - name: "Report Coverage"
         uses: davelosert/vitest-coverage-report-action@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-pr
-          path: coverage-pr
+          path: coverage
         env:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
@@ -87,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-main
-          path: coverage-main
+          path: coverage
         env:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
@@ -109,8 +109,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-pr
-          path: coverage-pr
-      - uses: actions/download-artifact@v4
+          path: coverage
+      - name: "Download Main Coverage"
+        uses: actions/download-artifact@v4
         with:
           name: coverage-main
           path: coverage-main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,8 +27,6 @@ jobs:
     permissions:
       # Required to checkout the code
       contents: read
-      # Required to put a comment into the pull-request
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -63,8 +61,6 @@ jobs:
     permissions:
       # Required to checkout the code
       contents: read
-      # Required to put a comment into the pull-request
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -102,6 +98,7 @@ jobs:
       pull-requests: write
 
     steps:
+      # This is needed to read the vitest.config.ts
       - uses: actions/checkout@v4
         with:
           ref: ${{github.head_ref}}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,120 @@
+name: Run Test Coverage
+on:
+  workflow_call:
+
+jobs:
+  install-dependencies:
+    name: Install Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install Dependencies
+        env:
+          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
+        run: npm install
+
+  test-coverage-pr:
+    name: Create Test Coverage PR
+    needs: install-dependencies
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to checkout the code
+      contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.head_ref}}
+          ## Set repository to correctly checkout from forks
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: "Install Node"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+      - name: "Install Dependencies"
+        env:
+          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
+        run: npm install
+      - name: "Test"
+        run: npx vitest --coverage.enabled true --coverage.reporter=json-summary || true
+      - name: "Upload Coverage"
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-pr
+          path: coverage
+        env:
+          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
+
+  test-coverage-main:
+    name: Create Test Coverage Main
+    needs: install-dependencies
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to checkout the code
+      contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          ## Set repository to correctly checkout from forks
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: "Install Node"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+      - name: "Install Dependencies"
+        env:
+          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
+        run: npm install
+      - name: "Test"
+        run: npx vitest --coverage.enabled true --coverage.reporter=json-summary || true
+      - name: "Upload Coverage"
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-main
+          path: coverage
+        env:
+          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
+
+  report-coverage:
+    needs: [test-coverage-pr, test-coverage-main]
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to checkout the code
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.head_ref}}
+          ## Set repository to correctly checkout from forks
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: "Download Coverage Artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-pr
+          path: coverage
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-main
+          path: coverage
+      - name: "Report Coverage"
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-compare-path: coverage-main/coverage-summary.json


### PR DESCRIPTION
# Ticket 🎫
This closes https://github.com/dot-base/.github/issues/64

# Description 📖
We want coverage reports on all repositories that use **vitest**.

## Is there something controversial ? 🚨
For now, not all of the repositories support vitest. Therefore we suggest to call the coverage report in the repository specific `manage-pr`s instead of calling it from the `manage-pr` of this repository. 
 
# How to Test? 🧪
- See this PR if the workflow is called: https://github.com/dot-base/data-graph/pull/252



# Breaking Changes ⚡️
This PR has
- [ ] no migrations
- [ ] no API changes (removing or changing existing APIs)
- [ ] no config changes
- [ ] no changes that require a change in other repos

BREAKING CHANGE: If you cannot tick all boxes, there is a breaking change. In this case, add a description here after the keyword. Otherwise DELETE this line or it will falsely trigger a major version change.
